### PR TITLE
Change a parameter value from 10k to 10000

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run:
 
 Here's a general matrix multiplication (Gemm) example already baked in to the nd4j-perf module:
 
-    java -cp lib/* org.nd4j.linalg.benchmark.app.BenchmarkRunnerApp -n 10k -r org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer,org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer
+    java -cp lib/* org.nd4j.linalg.benchmark.app.BenchmarkRunnerApp -n 10000 -r org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer,org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer
 
 ##IntelliJ
 


### PR DESCRIPTION
Hi, I'm Dongjoon Hyun from SK Telecom. 
It's a too small typo in README.md to create an issue.
Currently, the command line in README.md shows the following error.
```
$ java -cp target/nd4j-benchmark-1.0-SNAPSHOT.jar org.nd4j.linalg.benchmark.app.BenchmarkRunnerApp -n 10k -r org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer,org.nd4j.linalg.benchmark.gemm.GemmBenchmarkPerformer
"10k" is not a valid value for "-n"
```